### PR TITLE
Combine 'dependabot/' PRs

### DIFF
--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -18,7 +18,7 @@
     "stylelint-config-standard-scss": "^6.1.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.18",
+    "postcss": "^8.4.19",
     "prettier": "^2.7.1",
     "stylelint": "^14.14.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,7 +705,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vic1707/stylelint-config@workspace:packages/stylelint"
   dependencies:
-    postcss: "npm:^8.4.18"
+    postcss: "npm:^8.4.19"
     prettier: "npm:^2.7.1"
     stylelint: "npm:^14.14.1"
     stylelint-config-prettier: "npm:^9.0.3"
@@ -3169,6 +3169,17 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
   checksum: 686b922e5ced3d7dd5a6fe2d4b00f7787ac50db22f078f23f50462fdd9c00885e992f576c72eb804f62c5908a8b476d61d81d66ec91bb90eb4af2014eb3c321e
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.19":
+  version: 8.4.19
+  resolution: "postcss@npm:8.4.19"
+  dependencies:
+    nanoid: "npm:^3.3.4"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 583897de1f1b39bed59fecfd2697e34195d6f2f85710572a8f060a14898102e13b0a74a96fd5490b2f8bdc6ed51ae43169a5a24f37684606f7c8272221b5d111
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ This PR was created by combining the following PRs:
#7 - Bump postcss from 8.4.18 to 8.4.19

❌ The following PRs are not in a valid state:
#14 - status: blocked - Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.43.0
#11 - status: blocked - Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.15.2
#9 - status: blocked - Bump eslint-plugin-jest from 27.1.4 to 27.1.5
#6 - status: blocked - Bump actions/setup-node from 2 to 3<details><summary>PRs state (do not edit, it's used for future updates)</summary>

{"0":{"branchName":"dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-5.43.0","pull_number":14,"sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","mergeable":true,"mergeable_state":"blocked","title":"Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.43.0","status":"invalid"},"1":{"branchName":"dependabot/npm_and_yarn/darraghor/eslint-plugin-nestjs-typed-3.15.2","pull_number":11,"sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","mergeable":true,"mergeable_state":"blocked","title":"Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.15.2","status":"invalid"},"2":{"branchName":"dependabot/npm_and_yarn/eslint-plugin-jest-27.1.5","pull_number":9,"sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","mergeable":true,"mergeable_state":"blocked","title":"Bump eslint-plugin-jest from 27.1.4 to 27.1.5","status":"invalid"},"3":{"branchName":"dependabot/github_actions/actions/setup-node-3","pull_number":6,"sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","mergeable":true,"mergeable_state":"blocked","title":"Bump actions/setup-node from 2 to 3","status":"invalid"},"4":{"branchName":"dependabot/npm_and_yarn/postcss-8.4.19","pull_number":7,"sha":"99a89b93fc037847cc37c452404c4a86e904155e","mergeable":true,"mergeable_state":"clean","title":"Bump postcss from 8.4.18 to 8.4.19","status":"success"},"6":{"sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","status":"invalid"},"7":{"sha":"99a89b93fc037847cc37c452404c4a86e904155e","status":"success"},"9":{"sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","status":"invalid"},"11":{"sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","status":"invalid"},"14":{"sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"invalid"}}

</details>