### PR TITLE
Combine 'dependabot/' PRs

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@darraghor/eslint-plugin-nestjs-typed": "^3.15.1",
+    "@darraghor/eslint-plugin-nestjs-typed": "^3.15.2",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^5.42.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^27.1.4",
+    "eslint-plugin-jest": "^27.1.5",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -18,7 +18,7 @@
     "stylelint-config-standard-scss": "^6.1.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.18",
+    "postcss": "^8.4.19",
     "prettier": "^2.7.1",
     "stylelint": "^14.14.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,7 +674,7 @@ __metadata:
     eslint: "npm:^8.27.0"
     eslint-config-prettier: "npm:^8.5.0"
     eslint-plugin-import: "npm:^2.26.0"
-    eslint-plugin-jest: "npm:^27.1.4"
+    eslint-plugin-jest: "npm:^27.1.5"
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-react: "npm:^7.31.10"
     eslint-plugin-react-hooks: "npm:^4.6.0"
@@ -1417,9 +1417,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:^27.1.4":
-  version: 27.1.4
-  resolution: "eslint-plugin-jest@npm:27.1.4"
+"eslint-plugin-jest@npm:^27.1.5":
+  version: 27.1.5
+  resolution: "eslint-plugin-jest@npm:27.1.5"
   dependencies:
     "@typescript-eslint/utils": "npm:^5.10.0"
   peerDependencies:
@@ -1430,7 +1430,7 @@ __metadata:
       optional: true
     jest:
       optional: true
-  checksum: d66a651b9777ea586082ff1854ae266b8073810730e6a359de2144ce26ccb21a3f84544cf34f680a8a82edd86080acf1b93502742f93262aadbfe49202e1aaa0
+  checksum: 425d20964198836078820a879e1ac629f1f48221190c0aecd8ca6b09c54228ca445806fb1460c34fc8eb86fa937e9a42aef15d1f348eb184c5f2f4fd2d0511c7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,9 +286,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@darraghor/eslint-plugin-nestjs-typed@npm:^3.15.1":
-  version: 3.15.1
-  resolution: "@darraghor/eslint-plugin-nestjs-typed@npm:3.15.1"
+"@darraghor/eslint-plugin-nestjs-typed@npm:^3.15.2":
+  version: 3.15.2
+  resolution: "@darraghor/eslint-plugin-nestjs-typed@npm:3.15.2"
   dependencies:
     "@typescript-eslint/scope-manager": "npm:^5.0.0"
     "@typescript-eslint/utils": "npm:^5.0.0"
@@ -298,7 +298,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.0.0
     class-validator: "*"
     eslint: ^8.0.0
-  checksum: c4bcab9ea3e5ab791dadd1efb363adf40d48443739a2b5c8ce0003b039252c188b5d72577b2b38df11c02dc6f19a412031b16d3047d9aaba38bed7f558b01ecf
+  checksum: c12b58e8ebb68c6753e97c038668f79b8ddd8327bfef1a76ae6c1df12069c8dd49025b415c62193601ec0535e7bb39ff6bbeb3b6b4ca8c1c96062a1c7740f638
   languageName: node
   linkType: hard
 
@@ -667,7 +667,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vic1707/eslint-config@workspace:packages/eslint"
   dependencies:
-    "@darraghor/eslint-plugin-nestjs-typed": "npm:^3.15.1"
+    "@darraghor/eslint-plugin-nestjs-typed": "npm:^3.15.2"
     "@types/node": "npm:^18.11.9"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.0"
     "@typescript-eslint/parser": "npm:^5.42.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,7 +705,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vic1707/stylelint-config@workspace:packages/stylelint"
   dependencies:
-    postcss: "npm:^8.4.18"
+    postcss: "npm:^8.4.19"
     prettier: "npm:^2.7.1"
     stylelint: "npm:^14.14.1"
     stylelint-config-prettier: "npm:^9.0.3"
@@ -3169,6 +3169,17 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
   checksum: 686b922e5ced3d7dd5a6fe2d4b00f7787ac50db22f078f23f50462fdd9c00885e992f576c72eb804f62c5908a8b476d61d81d66ec91bb90eb4af2014eb3c321e
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.19":
+  version: 8.4.19
+  resolution: "postcss@npm:8.4.19"
+  dependencies:
+    nanoid: "npm:^3.3.4"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 583897de1f1b39bed59fecfd2697e34195d6f2f85710572a8f060a14898102e13b0a74a96fd5490b2f8bdc6ed51ae43169a5a24f37684606f7c8272221b5d111
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ This PR was created by combining the following PRs:
#9 - Bump eslint-plugin-jest from 27.1.4 to 27.1.5
#11 - Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.15.2

⚠️ The following PRs failed due to conflicts:
#14 - Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.43.0

❌ The following PRs are not in a valid state:
#6 - status: blocked - Bump actions/setup-node from 2 to 3
#7 - status: blocked - Bump postcss from 8.4.18 to 8.4.19

<details><summary>PRs state (do not edit, it's used for future updates)</summary>
{"6":{"mergeable":true,"mergeable_state":"blocked","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"invalid","title":"Bump actions/setup-node from 2 to 3"},"7":{"mergeable":true,"mergeable_state":"blocked","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"invalid","title":"Bump postcss from 8.4.18 to 8.4.19"},"9":{"mergeable":true,"mergeable_state":"clean","sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","status":"success","title":"Bump eslint-plugin-jest from 27.1.4 to 27.1.5"},"11":{"mergeable":true,"mergeable_state":"clean","sha":"0921822829ff5bb45d451d0fb7f5a9766af96c28","status":"success","title":"Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.15.2"},"14":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"merge-conflict","title":"Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.43.0"}}
</details>
🚨 This was last updated on 21/11/2022, 21:19:18