### PR TITLE
Combine 'dependabot/' PRs

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Install dependencies

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^5.42.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^27.1.4",
+    "eslint-plugin-jest": "^27.1.6",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,7 +674,7 @@ __metadata:
     eslint: "npm:^8.27.0"
     eslint-config-prettier: "npm:^8.5.0"
     eslint-plugin-import: "npm:^2.26.0"
-    eslint-plugin-jest: "npm:^27.1.4"
+    eslint-plugin-jest: "npm:^27.1.6"
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-react: "npm:^7.31.10"
     eslint-plugin-react-hooks: "npm:^4.6.0"
@@ -1417,9 +1417,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:^27.1.4":
-  version: 27.1.4
-  resolution: "eslint-plugin-jest@npm:27.1.4"
+"eslint-plugin-jest@npm:^27.1.6":
+  version: 27.1.6
+  resolution: "eslint-plugin-jest@npm:27.1.6"
   dependencies:
     "@typescript-eslint/utils": "npm:^5.10.0"
   peerDependencies:
@@ -1430,7 +1430,7 @@ __metadata:
       optional: true
     jest:
       optional: true
-  checksum: d66a651b9777ea586082ff1854ae266b8073810730e6a359de2144ce26ccb21a3f84544cf34f680a8a82edd86080acf1b93502742f93262aadbfe49202e1aaa0
+  checksum: 8c77f12b1e2f2946fbb25bdae034755104442aa97dedd4d7bffef2bd516f21d37f4cf27033e44246a56870e84838f364a5af483d2c0d6ae914392b4fff2b8fd9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ This PR was created by combining the following PRs:
#6 - Bump actions/setup-node from 2 to 3
#47 - Bump eslint-plugin-jest from 27.1.4 to 27.1.6

❌ The following PRs are not in a valid state:
#7 - status: blocked - Bump postcss from 8.4.18 to 8.4.19
#44 - status: blocked - Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.16.0
#45 - status: blocked - Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.44.0
#46 - status: blocked - Bump eslint-plugin-react from 7.31.10 to 7.31.11

<details><summary>PRs state (do not edit, it's used for future updates)</summary>
{"6":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"success","title":"Bump actions/setup-node from 2 to 3"},"7":{"mergeable":true,"mergeable_state":"blocked","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"invalid","title":"Bump postcss from 8.4.18 to 8.4.19"},"44":{"mergeable":true,"mergeable_state":"blocked","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"invalid","title":"Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.16.0"},"45":{"mergeable":true,"mergeable_state":"blocked","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"invalid","title":"Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.44.0"},"46":{"mergeable":true,"mergeable_state":"blocked","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"invalid","title":"Bump eslint-plugin-react from 7.31.10 to 7.31.11"},"47":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"success","title":"Bump eslint-plugin-jest from 27.1.4 to 27.1.6"}}
</details>
🚨 This was last updated on 28/11/2022, 17:26:14