### PR TITLE
Combine 'dependabot/' PRs

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Install dependencies

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -17,7 +17,7 @@
     "@typescript-eslint/parser": "^5.42.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^27.1.4",
+    "eslint-plugin-jest": "^27.1.6",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@darraghor/eslint-plugin-nestjs-typed": "^3.15.1",
+    "@darraghor/eslint-plugin-nestjs-typed": "^3.16.0",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.1.4",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react": "^7.31.10",
+    "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "eslint-plugin-solid": "^0.8.0",

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -18,7 +18,7 @@
     "stylelint-config-standard-scss": "^6.1.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.18",
+    "postcss": "^8.4.19",
     "prettier": "^2.7.1",
     "stylelint": "^14.14.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,7 +674,7 @@ __metadata:
     eslint: "npm:^8.27.0"
     eslint-config-prettier: "npm:^8.5.0"
     eslint-plugin-import: "npm:^2.26.0"
-    eslint-plugin-jest: "npm:^27.1.4"
+    eslint-plugin-jest: "npm:^27.1.6"
     eslint-plugin-prettier: "npm:^4.2.1"
     eslint-plugin-react: "npm:^7.31.11"
     eslint-plugin-react-hooks: "npm:^4.6.0"
@@ -1443,9 +1443,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:^27.1.4":
-  version: 27.1.4
-  resolution: "eslint-plugin-jest@npm:27.1.4"
+"eslint-plugin-jest@npm:^27.1.6":
+  version: 27.1.6
+  resolution: "eslint-plugin-jest@npm:27.1.6"
   dependencies:
     "@typescript-eslint/utils": "npm:^5.10.0"
   peerDependencies:
@@ -1456,7 +1456,7 @@ __metadata:
       optional: true
     jest:
       optional: true
-  checksum: d66a651b9777ea586082ff1854ae266b8073810730e6a359de2144ce26ccb21a3f84544cf34f680a8a82edd86080acf1b93502742f93262aadbfe49202e1aaa0
+  checksum: 8c77f12b1e2f2946fbb25bdae034755104442aa97dedd4d7bffef2bd516f21d37f4cf27033e44246a56870e84838f364a5af483d2c0d6ae914392b4fff2b8fd9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,9 +286,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@darraghor/eslint-plugin-nestjs-typed@npm:^3.15.1":
-  version: 3.15.1
-  resolution: "@darraghor/eslint-plugin-nestjs-typed@npm:3.15.1"
+"@darraghor/eslint-plugin-nestjs-typed@npm:^3.16.0":
+  version: 3.16.0
+  resolution: "@darraghor/eslint-plugin-nestjs-typed@npm:3.16.0"
   dependencies:
     "@typescript-eslint/scope-manager": "npm:^5.0.0"
     "@typescript-eslint/utils": "npm:^5.0.0"
@@ -298,7 +298,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.0.0
     class-validator: "*"
     eslint: ^8.0.0
-  checksum: c4bcab9ea3e5ab791dadd1efb363adf40d48443739a2b5c8ce0003b039252c188b5d72577b2b38df11c02dc6f19a412031b16d3047d9aaba38bed7f558b01ecf
+  checksum: 7e79971391dce3c17e62674967feb0edf66337ae1f42156d2c103d8ab074bd317e8d4ceac3e7be8de0b600a659a88933fc6b4437c4651cd1218913abc171339f
   languageName: node
   linkType: hard
 
@@ -667,7 +667,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vic1707/eslint-config@workspace:packages/eslint"
   dependencies:
-    "@darraghor/eslint-plugin-nestjs-typed": "npm:^3.15.1"
+    "@darraghor/eslint-plugin-nestjs-typed": "npm:^3.16.0"
     "@types/node": "npm:^18.11.9"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.0"
     "@typescript-eslint/parser": "npm:^5.42.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,7 +705,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vic1707/stylelint-config@workspace:packages/stylelint"
   dependencies:
-    postcss: "npm:^8.4.18"
+    postcss: "npm:^8.4.19"
     prettier: "npm:^2.7.1"
     stylelint: "npm:^14.14.1"
     stylelint-config-prettier: "npm:^9.0.3"
@@ -3196,6 +3196,17 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
   checksum: 686b922e5ced3d7dd5a6fe2d4b00f7787ac50db22f078f23f50462fdd9c00885e992f576c72eb804f62c5908a8b476d61d81d66ec91bb90eb4af2014eb3c321e
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.19":
+  version: 8.4.19
+  resolution: "postcss@npm:8.4.19"
+  dependencies:
+    nanoid: "npm:^3.3.4"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 583897de1f1b39bed59fecfd2697e34195d6f2f85710572a8f060a14898102e13b0a74a96fd5490b2f8bdc6ed51ae43169a5a24f37684606f7c8272221b5d111
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,7 +676,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.26.0"
     eslint-plugin-jest: "npm:^27.1.4"
     eslint-plugin-prettier: "npm:^4.2.1"
-    eslint-plugin-react: "npm:^7.31.10"
+    eslint-plugin-react: "npm:^7.31.11"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     eslint-plugin-simple-import-sort: "npm:^8.0.0"
     eslint-plugin-solid: "npm:^0.8.0"
@@ -831,6 +831,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-includes@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "array-includes@npm:3.1.6"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.4"
+    es-abstract: "npm:^1.20.4"
+    get-intrinsic: "npm:^1.1.3"
+    is-string: "npm:^1.0.7"
+  checksum: b4eb40ff992138350675662bb5a0351553d63bef17fb64c54e2ee9d6434ff3d8ba71d511af90a8f9400cd411c7311604310bd4ead1c101638c660461ea7916ae
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^2.1.0":
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
@@ -850,7 +863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flatmap@npm:^1.3.0":
+"array.prototype.flatmap@npm:^1.3.1":
   version: 1.3.1
   resolution: "array.prototype.flatmap@npm:1.3.1"
   dependencies:
@@ -859,6 +872,19 @@ __metadata:
     es-abstract: "npm:^1.20.4"
     es-shim-unscopables: "npm:^1.0.0"
   checksum: 7ce9fb7473ea95f24a19241318d5a4f5a69d262ad3352a38331ad3532880c6cca1d221cbc1527dd417535eca26d9c44be513d1a40c1097db9ebfa982ab64543f
+  languageName: node
+  linkType: hard
+
+"array.prototype.tosorted@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "array.prototype.tosorted@npm:1.1.1"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    define-properties: "npm:^1.1.4"
+    es-abstract: "npm:^1.20.4"
+    es-shim-unscopables: "npm:^1.0.0"
+    get-intrinsic: "npm:^1.1.3"
+  checksum: e86770e9d6500f44eb4da8d1ee278c39d8b8d3963b7a6ca3282d96a7b017e87ae20410b74747696fd2ddd621e481bf2fde9aa1ed1718592a09534b00ffb51cb5
   languageName: node
   linkType: hard
 
@@ -1288,7 +1314,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.19.0, es-abstract@npm:^1.19.1, es-abstract@npm:^1.19.5, es-abstract@npm:^1.20.4":
+"es-abstract@npm:^1.19.0, es-abstract@npm:^1.19.5, es-abstract@npm:^1.20.4":
   version: 1.20.4
   resolution: "es-abstract@npm:1.20.4"
   dependencies:
@@ -1458,27 +1484,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:^7.31.10":
-  version: 7.31.10
-  resolution: "eslint-plugin-react@npm:7.31.10"
+"eslint-plugin-react@npm:^7.31.11":
+  version: 7.31.11
+  resolution: "eslint-plugin-react@npm:7.31.11"
   dependencies:
-    array-includes: "npm:^3.1.5"
-    array.prototype.flatmap: "npm:^1.3.0"
+    array-includes: "npm:^3.1.6"
+    array.prototype.flatmap: "npm:^1.3.1"
+    array.prototype.tosorted: "npm:^1.1.1"
     doctrine: "npm:^2.1.0"
     estraverse: "npm:^5.3.0"
     jsx-ast-utils: "npm:^2.4.1 || ^3.0.0"
     minimatch: "npm:^3.1.2"
-    object.entries: "npm:^1.1.5"
-    object.fromentries: "npm:^2.0.5"
-    object.hasown: "npm:^1.1.1"
-    object.values: "npm:^1.1.5"
+    object.entries: "npm:^1.1.6"
+    object.fromentries: "npm:^2.0.6"
+    object.hasown: "npm:^1.1.2"
+    object.values: "npm:^1.1.6"
     prop-types: "npm:^15.8.1"
     resolve: "npm:^2.0.0-next.3"
     semver: "npm:^6.3.0"
-    string.prototype.matchall: "npm:^4.0.7"
+    string.prototype.matchall: "npm:^4.0.8"
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: 1f2862458a66039fbdf6f508b7bbc0feb7a63616feb2ea395a990511fc55eca13f00526c399a2eed7915bbda283dfab20d5be87a89e25cd184d3486a64633c1c
+  checksum: 99d223b6f074f92aa2c73c6ca23c11a85cc9fe183c555ab9f0b947b66dc9d904c995c03a55e345f59956e943d4926a667767c4fb4184e0bccf6b89b2beef3cf5
   languageName: node
   linkType: hard
 
@@ -2887,7 +2914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.5":
+"object.entries@npm:^1.1.6":
   version: 1.1.6
   resolution: "object.entries@npm:1.1.6"
   dependencies:
@@ -2898,7 +2925,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.fromentries@npm:^2.0.5":
+"object.fromentries@npm:^2.0.6":
   version: 2.0.6
   resolution: "object.fromentries@npm:2.0.6"
   dependencies:
@@ -2909,7 +2936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.hasown@npm:^1.1.1":
+"object.hasown@npm:^1.1.2":
   version: 1.1.2
   resolution: "object.hasown@npm:1.1.2"
   dependencies:
@@ -2919,7 +2946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.5":
+"object.values@npm:^1.1.5, object.values@npm:^1.1.6":
   version: 1.1.6
   resolution: "object.values@npm:1.1.6"
   dependencies:
@@ -3314,7 +3341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp.prototype.flags@npm:^1.4.1, regexp.prototype.flags@npm:^1.4.3":
+"regexp.prototype.flags@npm:^1.4.3":
   version: 1.4.3
   resolution: "regexp.prototype.flags@npm:1.4.3"
   dependencies:
@@ -3674,19 +3701,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string.prototype.matchall@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "string.prototype.matchall@npm:4.0.7"
+"string.prototype.matchall@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "string.prototype.matchall@npm:4.0.8"
   dependencies:
     call-bind: "npm:^1.0.2"
-    define-properties: "npm:^1.1.3"
-    es-abstract: "npm:^1.19.1"
-    get-intrinsic: "npm:^1.1.1"
+    define-properties: "npm:^1.1.4"
+    es-abstract: "npm:^1.20.4"
+    get-intrinsic: "npm:^1.1.3"
     has-symbols: "npm:^1.0.3"
     internal-slot: "npm:^1.0.3"
-    regexp.prototype.flags: "npm:^1.4.1"
+    regexp.prototype.flags: "npm:^1.4.3"
     side-channel: "npm:^1.0.4"
-  checksum: 25347979dc8b8852ef270f2f070b5993d29300d92901bad00d7370f213f60cf2a2e419fc9320c28fbfbaecc9719deffed2834eafacb5595f888c01297b0d948e
+  checksum: 3419a05feb3719ec9ad3d51fd29350d46e5b292b67df9488abe70ad50c37f7785a09e132c98b49a2750bf706792d0557da05967a95d828e0734054bea3939dd8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ This PR was created by combining the following PRs:
#6 - Bump actions/setup-node from 2 to 3
#7 - Bump postcss from 8.4.18 to 8.4.19
#44 - Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.16.0
#46 - Bump eslint-plugin-react from 7.31.10 to 7.31.11
#47 - Bump eslint-plugin-jest from 27.1.4 to 27.1.6

⚠️ The following PRs failed due to conflicts:
#58 - Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.45.0

<details><summary>PRs state (do not edit, it's used for future updates)</summary>
{"6":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"success","title":"Bump actions/setup-node from 2 to 3"},"7":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"success","title":"Bump postcss from 8.4.18 to 8.4.19"},"44":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"success","title":"Bump @darraghor/eslint-plugin-nestjs-typed from 3.15.1 to 3.16.0"},"46":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"success","title":"Bump eslint-plugin-react from 7.31.10 to 7.31.11"},"47":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"success","title":"Bump eslint-plugin-jest from 27.1.4 to 27.1.6"},"58":{"mergeable":true,"mergeable_state":"clean","sha":"c5fc2c529e27984d7a426411981ea88acd29b51c","status":"merge-conflict","title":"Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.45.0"}}
</details>
🚨 This was last updated on 01/12/2022, 12:02:52