### PR TITLE
Combine 'dependabot/' PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@changesets/cli": "^2.25.2",
     "@vic1707/eslint-config": "*",
     "@vic1707/prettier": "*",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.0",
     "turbo": "^1.6.3"
   },
   "packageManager": "yarn@4.0.0-rc.27",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@darraghor/eslint-plugin-nestjs-typed": "^3.16.0",
+    "@darraghor/eslint-plugin-nestjs-typed": "^3.17.1",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "^18.11.9",
     "eslint": "^8.27.0",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.0",
     "typescript": "^4.8.4"
   },
   "peerDependencies": {

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -18,7 +18,7 @@
     "stylelint-config-standard-scss": "^6.1.0"
   },
   "devDependencies": {
-    "postcss": "^8.4.18",
+    "postcss": "^8.4.19",
     "prettier": "^2.7.1",
     "stylelint": "^14.14.1"
   },

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "postcss": "^8.4.19",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.0",
     "stylelint": "^14.14.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,9 +286,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@darraghor/eslint-plugin-nestjs-typed@npm:^3.16.0":
-  version: 3.16.0
-  resolution: "@darraghor/eslint-plugin-nestjs-typed@npm:3.16.0"
+"@darraghor/eslint-plugin-nestjs-typed@npm:^3.17.1":
+  version: 3.17.1
+  resolution: "@darraghor/eslint-plugin-nestjs-typed@npm:3.17.1"
   dependencies:
     "@typescript-eslint/scope-manager": "npm:^5.0.0"
     "@typescript-eslint/utils": "npm:^5.0.0"
@@ -298,7 +298,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.0.0
     class-validator: "*"
     eslint: ^8.0.0
-  checksum: 7e79971391dce3c17e62674967feb0edf66337ae1f42156d2c103d8ab074bd317e8d4ceac3e7be8de0b600a659a88933fc6b4437c4651cd1218913abc171339f
+  checksum: 147f82e249241e0301ee1c5c1b260383f7d5558034dff62aadc3e67bd566d113f1c4252b9a732face8b67eadb83ac9b09241c7d2fa15ee5e24dd0c97021c0877
   languageName: node
   linkType: hard
 
@@ -667,7 +667,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vic1707/eslint-config@workspace:packages/eslint"
   dependencies:
-    "@darraghor/eslint-plugin-nestjs-typed": "npm:^3.16.0"
+    "@darraghor/eslint-plugin-nestjs-typed": "npm:^3.17.1"
     "@types/node": "npm:^18.11.9"
     "@typescript-eslint/eslint-plugin": "npm:^5.42.0"
     "@typescript-eslint/parser": "npm:^5.42.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -683,7 +683,7 @@ __metadata:
     eslint-plugin-typescript-sort-keys: "npm:^2.1.0"
     eslint-plugin-unused-imports: "npm:^2.0.0"
     eslint-plugin-vitest: "npm:^0.0.18"
-    prettier: "npm:^2.7.1"
+    prettier: "npm:^2.8.0"
     typescript: "npm:^4.8.4"
   peerDependencies:
     class-validator: "*"
@@ -706,7 +706,7 @@ __metadata:
   resolution: "@vic1707/stylelint-config@workspace:packages/stylelint"
   dependencies:
     postcss: "npm:^8.4.19"
-    prettier: "npm:^2.7.1"
+    prettier: "npm:^2.8.0"
     stylelint: "npm:^14.14.1"
     stylelint-config-prettier: "npm:^9.0.3"
     stylelint-config-prettier-scss: "npm:^0.0.1"
@@ -3247,6 +3247,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "prettier@npm:2.8.0"
+  bin:
+    prettier: bin-prettier.js
+  checksum: c95699326db607eac7f63274d38ca9c21462fa538fb69cf06cb3be2122f2d53daa02f96f69cffa985af852a95c6211472ddf3798dbdb2f20c520aded15f78684
+  languageName: node
+  linkType: hard
+
 "prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
@@ -3482,7 +3491,7 @@ __metadata:
     "@changesets/cli": "npm:^2.25.2"
     "@vic1707/eslint-config": "npm:*"
     "@vic1707/prettier": "npm:*"
-    prettier: "npm:^2.7.1"
+    prettier: "npm:^2.8.0"
     turbo: "npm:^1.6.3"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,7 +705,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vic1707/stylelint-config@workspace:packages/stylelint"
   dependencies:
-    postcss: "npm:^8.4.18"
+    postcss: "npm:^8.4.19"
     prettier: "npm:^2.7.1"
     stylelint: "npm:^14.14.1"
     stylelint-config-prettier: "npm:^9.0.3"
@@ -3196,6 +3196,17 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
   checksum: 686b922e5ced3d7dd5a6fe2d4b00f7787ac50db22f078f23f50462fdd9c00885e992f576c72eb804f62c5908a8b476d61d81d66ec91bb90eb4af2014eb3c321e
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.19":
+  version: 8.4.19
+  resolution: "postcss@npm:8.4.19"
+  dependencies:
+    nanoid: "npm:^3.3.4"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 583897de1f1b39bed59fecfd2697e34195d6f2f85710572a8f060a14898102e13b0a74a96fd5490b2f8bdc6ed51ae43169a5a24f37684606f7c8272221b5d111
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ This PR was created by combining the following PRs:
#62 - Bump @darraghor/eslint-plugin-nestjs-typed from 3.16.0 to 3.17.1
#65 - Bump prettier from 2.7.1 to 2.8.0

⚠️ The following PRs failed due to conflicts:
#58 - Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.45.0
#63 - Bump stylelint from 14.14.1 to 14.15.0
#64 - Bump eslint-plugin-vitest from 0.0.18 to 0.0.20

<details><summary>PRs state (do not edit, it's used for future updates)</summary>
{"58":{"mergeable":true,"mergeable_state":"clean","sha":"abd8639f2823a2d4f500997ef11117ac2be03bcc","status":"merge-conflict","title":"Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.45.0"},"62":{"mergeable":true,"mergeable_state":"clean","sha":"8096b69ab91735d4eb4cba529f14b10701b3e280","status":"success","title":"Bump @darraghor/eslint-plugin-nestjs-typed from 3.16.0 to 3.17.1"},"63":{"mergeable":true,"mergeable_state":"clean","sha":"abd8639f2823a2d4f500997ef11117ac2be03bcc","status":"merge-conflict","title":"Bump stylelint from 14.14.1 to 14.15.0"},"64":{"mergeable":true,"mergeable_state":"clean","sha":"abd8639f2823a2d4f500997ef11117ac2be03bcc","status":"merge-conflict","title":"Bump eslint-plugin-vitest from 0.0.18 to 0.0.20"},"65":{"mergeable":true,"mergeable_state":"clean","sha":"abd8639f2823a2d4f500997ef11117ac2be03bcc","status":"success","title":"Bump prettier from 2.7.1 to 2.8.0"}}
</details>
🚨 This was last updated on 01/12/2022, 12:21:41