### PR TITLE
Combine 'dependabot/' PRs

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^18.11.9",
     "eslint": "^8.27.0",
     "prettier": "^2.8.0",
-    "typescript": "^4.8.4"
+    "typescript": "^4.9.3"
   },
   "peerDependencies": {
     "class-validator": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,7 +747,7 @@ __metadata:
     eslint-plugin-unused-imports: "npm:^2.0.0"
     eslint-plugin-vitest: "npm:^0.0.20"
     prettier: "npm:^2.8.0"
-    typescript: "npm:^4.8.4"
+    typescript: "npm:^4.9.3"
   peerDependencies:
     class-validator: "*"
     eslint: "*"
@@ -4257,23 +4257,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.8.4":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:^4.9.3":
+  version: 4.9.3
+  resolution: "typescript@npm:4.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 008c336ed785130b6e13254adbfc4084f5dbbe62851df9bac3eaf62fc29e0a396839c00ce47e0d92db44fa9a08b9f7ba4d31304f2b10cf7d42a0817728e822a1
+  checksum: b0aafee5d6427b67fc557c46a6e9c093586444db463fde7a19ffc4eecc31889246210ff679f8384769dc99fca975bba5ac17411816855bb2d8a549e4fe442cc7
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.8.4#optional!builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#optional!builtin<compat/typescript>::version=4.8.4&hash=0102e9"
+"typescript@patch:typescript@npm%3A^4.9.3#optional!builtin<compat/typescript>":
+  version: 4.9.3
+  resolution: "typescript@patch:typescript@npm%3A4.9.3#optional!builtin<compat/typescript>::version=4.9.3&hash=7f4d21"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 72574875bac1c13aec22010780d4841a10a88342d73744dbbad538bb0ed601f2024187f197239f2dcbf2442f83ecc4de04a80941d49730c403969fbba035ed81
+  checksum: e449b7c143ae3e87375ffb8be9a37880c6d61720337fcc7c211b129fc8f43016c366cd9f1d0c13f35cd3a1ffe4f108f0ededc75eb70e8cfeac4e5a8f011e3f82
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ This PR was created by combining the following PRs:
#72 - Bump typescript from 4.8.4 to 4.9.3

❌ The following PRs are not in a valid state:
#68 - status: blocked - Bump @types/node from 18.11.9 to 18.11.10
#69 - status: blocked - Bump eslint-plugin-solid from 0.8.0 to 0.9.1
#70 - status: blocked - Bump stylelint-config-prettier from 9.0.3 to 9.0.4
#71 - status: blocked - Bump @typescript-eslint/parser from 5.42.0 to 5.45.0

<details><summary>PRs state (do not edit, it's used for future updates)</summary>
```json

{"68":{"mergeable":true,"mergeable_state":"blocked","sha":"1e7861afc0c82f35030fe5852b433a97d5493216","status":"invalid","title":"Bump @types/node from 18.11.9 to 18.11.10"},"69":{"mergeable":true,"mergeable_state":"blocked","sha":"1e7861afc0c82f35030fe5852b433a97d5493216","status":"invalid","title":"Bump eslint-plugin-solid from 0.8.0 to 0.9.1"},"70":{"mergeable":true,"mergeable_state":"blocked","sha":"1e7861afc0c82f35030fe5852b433a97d5493216","status":"invalid","title":"Bump stylelint-config-prettier from 9.0.3 to 9.0.4"},"71":{"mergeable":true,"mergeable_state":"blocked","sha":"1e7861afc0c82f35030fe5852b433a97d5493216","status":"invalid","title":"Bump @typescript-eslint/parser from 5.42.0 to 5.45.0"},"72":{"mergeable":true,"mergeable_state":"clean","sha":"1e7861afc0c82f35030fe5852b433a97d5493216","status":"success","title":"Bump typescript from 4.8.4 to 4.9.3"}}
```
</details>
🚨 This was last updated on 02/12/2022, 18:02:10